### PR TITLE
Ensure dreyfus index module is loaded

### DIFF
--- a/rel/files/couchdb.in
+++ b/rel/files/couchdb.in
@@ -33,6 +33,10 @@ export COUCHDB_FAUXTON_DOCROOT={{fauxton_root}}
 ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
 SYSCONFIG_FILE="${COUCHDB_SYSCONFIG_FILE:-$ROOTDIR/releases/$APP_VSN/sys.config}"
 
+if [ -e "${COUCHDB_BIN_DIR}/startup.erl" ]; then
+  cat "${COUCHDB_BIN_DIR}/startup.erl" > .erlang
+fi
+
 exec "$BINDIR/erlexec" -boot "$ROOTDIR/releases/$APP_VSN/couchdb" \
      -args_file "${ARGS_FILE}" \
      -config "${SYSCONFIG_FILE}" "$@"

--- a/rel/files/startup.erl.in
+++ b/rel/files/startup.erl.in
@@ -1,0 +1,6 @@
+% Command to run on startup.
+
+code:add_path("./lib").
+
+Result = code:ensure_loaded(dreyfus_index).
+couch_log:info("Ensure dreyfus index module is loaded: ~p", [Result]).

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -135,5 +135,6 @@
     {template, "overlay/etc/default.ini", "etc/default.ini"},
     {template, "overlay/etc/vm.args", "etc/vm.args"},
     {template, "files/couchdb.in", "bin/couchdb"},
+    {template, "files/startup.erl.in", "bin/startup.erl"},
     {template, "files/couchdb.cmd.in", "bin/couchdb.cmd"}
 ]}.


### PR DESCRIPTION
In development mode (dev/run) the dreyfus_index module is loaded by
startup. For release mode no such loading is done, instead modules are
loaded "on demand". In mango code, all use of dreyfus_index is protected
by checking if module is loaded (by calling module_loaded(dreyfus_index)).

This commit adds startup.erl containing code to be run during startup
of couchdb release (rel/couchdb/bin/couchdb) that fixes the error
occuring from dreyfus_index not being loaded.

For a seasoned couchdb or erlang developer this might seem to be a
trivial thing to fix, as for them the use of .erlang in working directory
is a well-known feature. Others might find this useful as it makes
couchdb with dreyfus working "out-of-the-box" in release mode too.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Solves loading of dreyfus_index (and other modules) running couchdb in release mode.

## Testing recommendations

Configure, build and start release mode:

bash$> ./configure --disable-fauxton --disable-docs
bash$> make release
bash$> ./rel/couchdb/bin/couchdb

In another shell, test create an index all text:

bash$> curl -XPUT -H "Content-Type: application/json" http://127.0.0.1:5984/test1
bash$> curl -XPOST -H "Content-Type: application/json" http://127.0.0.1:5984/test1/_index -d '{"index":{},"type":"text"}'

## Related Issues or Pull Requests

Perhaps the startup.erl should be config protected by install as startup.erl.in from rel/reltool.config

## Checklist

- [x ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x ] Documentation reflects the changes;
